### PR TITLE
タスク編集ボタンをトグルできるようにしました

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ go build
 ## Author
 Mox [Twitter](http://twitter.com/__MOX__) / [Github](https://github.com/moezakura)  
 uryoya [Github](https://github.com/uryoya)  
-nishi3 [Github](https://github.com/nishi3)  
+nishi3 [Github](https://github.com/nishi3)
+nitoling [Github](https://github.com/nitoling)
 
 ## Version
 - 0.1 (Alpha)

--- a/www/assets/js/taskDetail.js
+++ b/www/assets/js/taskDetail.js
@@ -54,6 +54,7 @@ export default class TaskDetail {
         TaskDetail.setEmpty(true);
         let taskPopup = document.querySelector("#taskPopup");
         taskPopup.dataset.taskId = taskId;
+        taskPopup.dataset.isEditable = "0";
 
         let loadView = new LoadingView();
         loadView.isDisporse = true;
@@ -101,7 +102,7 @@ export default class TaskDetail {
             taskPopupCreator = taskPopup.querySelector("#taskPopupCreator"),
             taskPopupProgressCurrent = document.querySelector("#taskPopupProgressCurrent");
 
-        this.editable(!readOnly);
+        this.setEditable(!readOnly);
         taskPopup.dataset.taskId = "";
         taskDetailTitle.innerText = "";
         taskPopupTaskId.innerText = "#";
@@ -134,7 +135,7 @@ export default class TaskDetail {
 
         taskPopup.dataset.taskCreatedDate = taskObject.createDate;
 
-        this.editable(false);
+        this.setEditable(false);
         taskDetailTitle.innerText = statusText + " Task Detail";
 
         taskPopupTaskId.innerText = "#" + taskObject.taskId;
@@ -202,7 +203,21 @@ export default class TaskDetail {
         return limit / allDiff * 100;
     }
 
-    static editable(isEdit) {
+    static toggleEditable()
+    {
+        this.setEditable(!this.getEditable());
+    }
+
+    static getEditable()
+    {
+        let taskPopup = document.querySelector("#taskPopup");
+        return taskPopup.dataset.isEditable == "1" ? true : false;
+    }
+
+    static setEditable(isEdit) {
+        let taskPopup = document.querySelector("#taskPopup");
+        taskPopup.dataset.isEditable = isEdit ? "1" : "0";
+
         let taskPopupInputs = taskPopup.querySelectorAll("input, textarea");
         taskPopupInputs.forEach(function (value) {
             value.readOnly = !isEdit;

--- a/www/assets/js/taskEdit.js
+++ b/www/assets/js/taskEdit.js
@@ -62,7 +62,7 @@ class TaskEdit {
     }
 
     static editClick() {
-        TaskDetail.editable(true);
+        TaskDetail.toggleEditable();
     }
 
     static taskDeadlineChange(createDate, deadline) {
@@ -123,7 +123,7 @@ class TaskEdit {
                 that.showError(json.message);
             }else{
                 that.showSuccess();
-                TaskDetail.editable(false);
+                TaskDetail.setEditable(false);
             }
             TaskDetail.load(taskId).then(function(task){
                 if(task == null) return;


### PR DESCRIPTION
タスク詳細画面からタスクの情報を変更できるボタンがあるのですが、
あのボタンを押して編集モードに入ったあと、もう一度押すと編集モードから抜けるようにしました。

また、その周辺の関数の命名規則を改めました。
それ以外は特別なことはしていません。

# 変更内容
* `#taskPopup`のdatasetに`isEditable`を追加しました
    * 0か1が入っています
    * これにeditableかどうかを格納しています
* `getEditable`と`toggleEditable`関数を追加しました
    * `isEditable`まわりをいい感じに読み出したりする関数です
* `editable`関数を`setEditable`関数に変更しました
    * `editable`だけだとgetter/setterが不明瞭だからです

# 見てほしい部分
* datasetを扱ったことがないので、その周辺